### PR TITLE
Removing images when on small screen

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -62,7 +62,7 @@
 			<!--If search successful, details below-->
 			<div id="info" style="display: none; margin-top: 1em;">
 				<div>
-					<p>You live in <b>Ward <span class="ward-name"> </span>&rsquo;s ANC <span class="anc-short-name"> </span></b>.
+					<p>You live in <b>ANC <span class="anc-short-name"> </span></b> within <b>Ward <span class="ward-name"> </span></b>.
 					It&rsquo;s called <span class="anc-name"> </span> for short.</p>
 					
 					<p>Your single member district is <b><span class="smd-name"> </span></b>.</p>
@@ -231,6 +231,11 @@
 				});
 				return false;
 			});
+			
+			if ($(window).width() < 767) {
+				$('.image img').hide();
+				$('div#jump_to_top').css({ 'padding-top': '8em' });
+			};
 		}
 
 		function resize_things() {
@@ -247,7 +252,7 @@
 		
 		/*** FOR GOOGLE MAPS API V3 ***/
 		function initialize_google() {
-			// Create a basic roadmap centered on the United States.
+			// Create a basic roadmap centered on Washington, DC.
 			var myOptions = {
 				zoom: 4,
 				center: new google.maps.LatLng(38, -96),


### PR DESCRIPTION
This should remove images when screen width is less than 767px, which seemed like the right number to use based on the stylesheet. It also bumps the "jump to top" link down some to account for the image being gone.

There are also two minor copy-edits.
