### PR TITLE
new header to take advantage of Bootstrap and fix breakpoints

### DIFF
--- a/ancbrigadesite/static/css/theme.css
+++ b/ancbrigadesite/static/css/theme.css
@@ -479,6 +479,9 @@ div#use_my_location {
     .navbar-inverse .navbar-nav>li>a {
         padding-left: 15px;
     }
+    nav .col-sm-10 {
+        font-size: 15px;
+    }
 }
 @media (max-width: 420px) {
 	#map_canvas_google {

--- a/ancbrigadesite/templates/master.html
+++ b/ancbrigadesite/templates/master.html
@@ -26,7 +26,7 @@
 </head>
 <body>
     <nav class='navbar navbar-inverse' role='navigation'>
-        <div class='container-fluid'>
+        <div class='container'>
             <div class='navbar-header'>
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
                     <span class="sr-only">Toggle navigation</span>


### PR DESCRIPTION
This should prevent line wrapping in the header on smaller screens, and uses Bootstrap's built-in dropdown menu below 790px or so. I don't think that I broke anything. @JoshData, what do you think?
