### PR TITLE
add error handling for missing HTML

### DIFF
--- a/scripts/scrape_anc.py
+++ b/scripts/scrape_anc.py
@@ -58,7 +58,10 @@ for anc in ANC:
         elif len(phone) < 8:
             phone = ''
         data[smd]['phone'] = phone
-        data[smd]['email'] = td[4].a.text
+        try:
+            data[smd]['email'] = td[4].a.text
+        except IndexError:
+            pass    
         #print data[smd]
 
 with open('data/scraped-anc.json', 'w') as output:


### PR DESCRIPTION
The anc.dc.gov site sometimes doesn't have the phone field in its table. That breaks the scraper. There's more that can be done to put things in the proper fields, but this will at least allow it to run.